### PR TITLE
Change subject parameter

### DIFF
--- a/src/app/email-processor/email-processor.tsx
+++ b/src/app/email-processor/email-processor.tsx
@@ -6,7 +6,7 @@ import { EmailProcessorProps } from './email-processor.types';
 import { TemplateDataGroup, TemplateGroup } from '../../template-builder/template.types';
 
 const buildGmailLink = ({ email, body, subject }) =>
-    `https://mail.google.com/mail/u/0/?view=cm&fs=1&tf=1&to=${email}&subject=${encodeURIComponent(
+    `https://mail.google.com/mail/u/0/?view=cm&fs=1&tf=1&to=${email}&su=${encodeURIComponent(
         subject
     )}&body=${encodeURIComponent(body)}`;
 


### PR DESCRIPTION
- Change subject parameter from `&subject=` to`&su=` to fix missing subject line for gmail in generated emails