### PR TITLE
Add line for request of special prosecutor

### DIFF
--- a/templates/louisville/louisville_mayor.txt
+++ b/templates/louisville/louisville_mayor.txt
@@ -11,6 +11,7 @@ Like thousands of people across the country, I was appalled to hear about Breonn
 2. The officers that killed Breonna must be fired, and have their pensions revoked
 3. Ensure that all necessary information is provided to a local, independent civilian community police accountability council
 4. Create policy for a transparent investigation process due to law enforcement misconduct
+5. Appoint a special prosecutor to bring forward charges against the officers and oversee all parts of this case. 
 
 It is imperative that you condemn the actions of these officers. Raids cannot be performed with a shoot first, ask questions later mentality. Too many lives have been lost this way, and too often "danger" is determined by deeply entrenched racial biases, not actual threat level.
 


### PR DESCRIPTION
- Added 5th point on appointment of a special prosecutor.

On the stand with Bre site created for Breonna Taylor ([here](https://www.standwithbre.com/)) the call to action is worded this way:

> We’re calling on the Louisville Metro Police Department to terminate the police involved, and for a special prosecutor to be appointed to bring forward charges against the officers and oversee all parts of this case.

I was wondering about your thoughts on adding this part about the special prosecutor as a fifth point in the Louisville email?


